### PR TITLE
Bonus challenge button

### DIFF
--- a/app/assets/stylesheets/challenges/_show.scss
+++ b/app/assets/stylesheets/challenges/_show.scss
@@ -44,10 +44,6 @@
   text-align: center;
 }
 
-.button-read {
-  margin-bottom: 20px;
-}
-
 .data-challenge {
   flex-grow: 1;
 }

--- a/app/controllers/challenge_users_controller.rb
+++ b/app/controllers/challenge_users_controller.rb
@@ -14,7 +14,7 @@ class ChallengeUsersController < ApplicationController
     @challenge_user.opt_completed = true
     @challenge_user.save
     sleep (3.0)
-    redirect_to challenge_path(@challenge)
+    redirect_to dashboard_path(@user)
   end
 
   private

--- a/app/views/challenges/show.html.erb
+++ b/app/views/challenges/show.html.erb
@@ -65,7 +65,7 @@
           <%= link_to 'Read more', @challenge.infobox_link, target: "_blank", class: "link-color btn-green-bird-empty btn-medium-size" %>
         </div>
         <% if @instance.opt_completed %>
-          <%= link_to "You've already completed this challenge!", 'javascript:;', class: "link-color btn-green-bird-done btn-medium-size", style: "color: white; text-decoration: none" %>
+          <%= button_to "Already completed!", @challenge, disabled: true, class: "link-color btn-green-bird-done btn-medium-size" %>
         <% else %>
           <%= button_to 'Bonus challenge done!', update_opt_challenge_challenge_user_path(@challenge, @instance.id), method: :patch, id: "sweet-alert-demo", class: "link-color btn-green-bird btn-medium-size" %>
         <% end %>


### PR DESCRIPTION
- changed link_to to a button_to because there was no other way to add the margin we needed to unstick the buttons
- shortened button text to "Already completed!" so it's the same as the button on top
- doing a bonus challenge now redirects to the dashboard instead of reloading the challenge page. I think it makes for a better user experience – what do you think? 
- refactoring: deleted css for button-read because it wasn't doing anything

<img width="1440" alt="Screenshot 2020-09-11 at 16 09 54" src="https://user-images.githubusercontent.com/67542297/92935828-9ce0f580-f449-11ea-9196-5d0206c3f54b.png">
